### PR TITLE
Fix clear_control_payload::acked_pktid_list size description

### DIFF
--- a/openvpn-wire-protocol.xml
+++ b/openvpn-wire-protocol.xml
@@ -477,7 +477,7 @@ struct tlscrypt_control {
             <artwork>
 struct clear_control_payload {
    uint8_t acked_pktid_len;
-   uint8_t[n*8] acked_pktid_list; [only if acked_pktid_len > 0]
+   uint8_t[n*4] acked_pktid_list; [only if acked_pktid_len > 0]
    uint64_t peer_session_id; [only if acked_pktid_len > 0]
    uint32_t packet_id;
    uint8_t control_channel_payload[];


### PR DESCRIPTION
Packet IDs are 32-bit (so 4 bytes), which means that for `n` IDs we need a `[n*4]` `uint8_t` array to store them (as opposed to `n*8`).